### PR TITLE
fix: Changed use of risky cryptographic algorithm for CWE-327

### DIFF
--- a/starter/cloudstorage/src/main/java/com/udacity/jwdnd/course1/cloudstorage/services/HashService.java
+++ b/starter/cloudstorage/src/main/java/com/udacity/jwdnd/course1/cloudstorage/services/HashService.java
@@ -11,16 +11,19 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Base64;
 
-@Component
+@Service
 public class HashService {
-    private Logger logger = LoggerFactory.getLogger(HashService.class);
+
+    public final Logger logger = LoggerFactory.getLogger(HashService.class);
 
     public String getHashedValue(String data, String salt) {
         byte[] hashedValue = null;
 
-        KeySpec spec = new PBEKeySpec(data.toCharArray(), salt.getBytes(), 5000, 128);
+        int iterCount = 12288;
+        int derivedKeyLength = 256;
+        KeySpec spec = new PBEKeySpec(data.toCharArray(), salt.getBytes(), iterCount, derivedKeyLength * 8);
         try {
-            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
             hashedValue = factory.generateSecret(spec).getEncoded();
         } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
             logger.error(e.getMessage());
@@ -28,4 +31,5 @@ public class HashService {
 
         return Base64.getEncoder().encodeToString(hashedValue);
     }
+
 }


### PR DESCRIPTION
Hi there, 

I did a code scan with CodeQL and it returned CWE-327 for this class:
https://cwe.mitre.org/data/definitions/327.html

I applied the fix as suggested, I hope it can be useful.

